### PR TITLE
Allow PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "contao/core-bundle": "~4.9",
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "ext-curl": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Hey, danke für die Extension!

Ich habe zwar aktuell Probleme, weil das `decodeEntities = true` in `sourceWhere` nicht zu greifen scheint (`SELECT DISTINCT id,lastname FROM tl_member WHERE groups LIKE &#34;%\&#34;1\&#34;%&#34;`).

Ansonsten läuft die Erweiterung (ohne WHERE-Einschränkung) so weit ich das getestet habe gut in PHP 8, deshalb wäre ich dir dankbar, wenn du PHP 8 erlauben würdest. Würde mir das Debuggen erleichtern, dann muss ich nicht meinen Fork einbinden.

Vielen Dank!